### PR TITLE
Enhanced signal cleaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 bin
 test/**/bin
+
+.idea/
+*.iml

--- a/src/git-octopus
+++ b/src/git-octopus
@@ -16,16 +16,16 @@ line_break(){
 triggeredBranch=$(git symbolic-ref --short HEAD 2> /dev/null) ||
     triggeredBranch=$(git rev-parse HEAD)
 
-resetRepository(){
+signalHandler(){
     echo
     line_break
     echo "Stoping..."
     echo "HEAD -> $triggeredBranch"
     git reset -q --hard
     git checkout -q $triggeredBranch
+    git clean -d -f
+    exit 1
 }
-
-trap "resetRepository && exit 1;" SIGINT SIGQUIT
 
 doCommit=$(git config octopus.commit)
 
@@ -47,11 +47,9 @@ while getopts "nhv" opt; do
   esac
 done
 
-if [[ -n "$(git diff-index HEAD)" ]]
-then
-    echo "The repository has to be clean"
-    exit 1
-fi
+[[ -z $(git status --porcelain) ]] || die "The repository has to be clean"
+
+trap signalHandler SIGINT SIGQUIT
 
 #Shift all options in order to iterate over refspec-patterns
 shift $(expr $OPTIND - 1)

--- a/src/git-octopus
+++ b/src/git-octopus
@@ -13,12 +13,8 @@ line_break(){
 }
 
 # Save the current state of the repository in $triggeredBranch
-triggeredBranch=$(git symbolic-ref HEAD 2> /dev/null)
-if [ $? -eq 0 ] ; then
-    triggeredBranch=${triggeredBranch#refs/heads/}
-else
+triggeredBranch=$(git symbolic-ref --short HEAD 2> /dev/null) ||
     triggeredBranch=$(git rev-parse HEAD)
-fi
 
 resetRepository(){
     echo


### PR DESCRIPTION
- We clean the repository only if we now it is clean (we don't want to reset the worspace while handling signals if it has unstaged changes when running git-octopus)
- When the automatic conflic resolution is used, the cleaning done when handling signals is not complete. Once the clean is done, the worspace is in the following state:
  $ git status
  On branch brahcn_test
  Untracked files:
  (use "git add <file>..." to include in what will be committed)
  
    .merge_file_7cDsQc
    .merge_file_C2reWa
    .merge_file_KgLfZO
    .merge_file_Zmfz3c
    .merge_file_hnrfMH

nothing added to commit but untracked files present (use "git add" to track)
