### PR TITLE
Performance improvement on cat-UU-conflict

### DIFF
--- a/src/lib/hash-conflict
+++ b/src/lib/hash-conflict
@@ -3,10 +3,10 @@ cat-UU-conflict() {
 	rightContent=
 	reading="base"
 
-	while read l ; do 
-		echo $l | grep '^<<<<<<<' 1> /dev/null && reading="left" && continue
-		echo $l | grep '^=======' 1> /dev/null && reading="right" && continue
-		echo $l | grep '^>>>>>>>' 1> /dev/null && reading="base" && continue
+	while read l ; do
+		[[ $l == \<\<\<\<\<\<\<* ]] && reading="left" && continue
+		[[ $l == \=\=\=\=\=\=\=* ]] && reading="right" && continue
+		[[ $l == \>\>\>\>\>\>\>* ]] && reading="base" && continue
 
 		case $reading in
 			"base")


### PR DESCRIPTION
git-conflict is really awesome, but on file that has too many lines (I first noticed the issue on a 500 line file) it's very slow (at least on windows, I didn't test on Linux but I suspect this is less problematic on this plateform).
The reason is that on Windows the while loop in cat-UU-conflict si calling 3 grep per loop: this spawn 3 bash.exe and then grep.exe and this seems to be very slow.
At first I wanted to try an different approach in one pass (with awk or perl for exemple), but then I realized than just by using bash "start with" operator improve drastically the time to complete the command.

Please find below some time differences on a 2000 line demo file (project is here https://github.com/benba/conflict-perf-demo and the recorded conflict is in refs/conflicts/2b2273b9ff812101ee21db6094fefa854d95cf04):
### Without a recorded conflict (before) - 1m21.361s:

`$ git reset --hard && time git octopus -n feature*`

```
HEAD is now at 8ee0da3 Init
Branches beeing merged :
        refs/heads/feature1
        refs/heads/feature2
        refs/heads/feature3
        refs/heads/feature4
-----------------------------------------------------------
Fast-forwarding to: refs/heads/feature1
Trying simple merge with refs/heads/feature2
Simple merge did not work, trying automatic merge.
Auto-merging README.txt
Trying simple merge with refs/heads/feature3
Simple merge did not work, trying automatic merge.
Auto-merging README.txt
ERROR: content conflict in README.txt
fatal: merge program failed
Automated merge did not work.
Should not be doing an Octopus.
-----------------------------------------------------------
...
-----------------------------------------------------------
No conflicts found between octopus and the rest of the branches
OCTOPUS FAILED

real    1m21.361s
user    0m0.000s
sys     0m0.000s
```
### Without a recorded conflict (after) - 0m3.038s:

`$ git reset --hard && time git octopus -n feature*`

```
HEAD is now at 8ee0da3 Init
Branches beeing merged :
        refs/heads/feature1
        refs/heads/feature2
        refs/heads/feature3
        refs/heads/feature4
-----------------------------------------------------------
Fast-forwarding to: refs/heads/feature1
Trying simple merge with refs/heads/feature2
Simple merge did not work, trying automatic merge.
Auto-merging README.txt
Trying simple merge with refs/heads/feature3
Simple merge did not work, trying automatic merge.
Auto-merging README.txt
ERROR: content conflict in README.txt
fatal: merge program failed
Automated merge did not work.
Should not be doing an Octopus.
-----------------------------------------------------------
...
-----------------------------------------------------------
No conflicts found between octopus and the rest of the branches
OCTOPUS FAILED

real    0m3.038s
user    0m0.000s
sys     0m0.015s
```
### With a recorded conflict (before) - 3m59.042s:

`$ git reset --hard && time git octopus -n feature*`

```
HEAD is now at 8ee0da3 Init
Branches beeing merged :
        refs/heads/feature1
        refs/heads/feature2
        refs/heads/feature3
        refs/heads/feature4
-----------------------------------------------------------
Fast-forwarding to: refs/heads/feature1
Trying simple merge with refs/heads/feature2
Simple merge did not work, trying automatic merge.
Auto-merging README.txt
Trying simple merge with refs/heads/feature3
Simple merge did not work, trying automatic merge.
Auto-merging README.txt
ERROR: content conflict in README.txt
fatal: merge program failed
Applying conflict resolution 2b2273b9ff812101ee21db6094fefa854d95cf04
Trying simple merge with refs/heads/feature4
Simple merge did not work, trying automatic merge.
Auto-merging README.txt
-----------------------------------------------------------
OCTOPUS SUCCESS

real    3m59.042s
user    0m0.000s
sys     0m0.031s
```
### With a recorded conflict (after) - 0m3.262s:

`$ git reset --hard && time git octopus -n feature*`

```
HEAD is now at 8ee0da3 Init
Branches beeing merged :
        refs/heads/feature1
        refs/heads/feature2
        refs/heads/feature3
        refs/heads/feature4
-----------------------------------------------------------
Fast-forwarding to: refs/heads/feature1
Trying simple merge with refs/heads/feature2
Simple merge did not work, trying automatic merge.
Auto-merging README.txt
Trying simple merge with refs/heads/feature3
Simple merge did not work, trying automatic merge.
Auto-merging README.txt
ERROR: content conflict in README.txt
fatal: merge program failed
Applying conflict resolution 2b2273b9ff812101ee21db6094fefa854d95cf04
Trying simple merge with refs/heads/feature4
Simple merge did not work, trying automatic merge.
Auto-merging README.txt
-----------------------------------------------------------
OCTOPUS SUCCESS

real    0m3.262s
user    0m0.000s
sys     0m0.015s
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lesfurets/git-octopus/15)

<!-- Reviewable:end -->
