### PR TITLE
Exclude pattern

### DIFF
--- a/src/doc/git-octopus.1.txt
+++ b/src/doc/git-octopus.1.txt
@@ -12,7 +12,7 @@ git-octopus - extends git-merge with branch naming patterns.
 SYNOPSIS
 --------
 [verse]
-'git octopus' [-n|-c] [-s <n>] [<pattern>...]
+'git octopus' [-n|-c] [-s <n>] [-e <pattern>] [<pattern>...]
 'git octopus' -v
 
 DESCRIPTION
@@ -39,6 +39,10 @@ Commit the resulting merge in the current branch. This is the default behavior u
 +
 Chunk mode: the merge is performed by subsets of <n> branches. This is meant to help reading the log graph when lots of branches are merged.
 
+-e <pattern>::
++
+Exclude pattern: the merge excludes branches matching the <pattern>.
+
 -v::
 +
 Prints the version of `git-octopus`
@@ -63,6 +67,9 @@ octopus.pattern::
 +
 Defines a branch naming pattern that 'git octopus' would use by default. Use multiple lines to define several patterns. See link:git-config.html[git-config(1)].
 
+octopus.excludePattern::
++
+Defines a branch naming pattern that 'git octopus' will exclude by default.
 
 SEE ALSO
 --------

--- a/src/git-octopus
+++ b/src/git-octopus
@@ -5,12 +5,22 @@ usage: git octopus [options] [<pattern>...]
     -n     leaves the repository back to HEAD
     -c     Commit the resulting merge in the current branch.
     -s <n> do the octopus by chunk of n branches.
+    -e <p> exclude branches matching the pattern.
     -v     prints the version of git-octopus
 EOF
 exit
 }
 
-line_break(){
+removeAllFrom() {
+    from=$1
+    remove=$2
+    for i in $remove; do
+        from=${from/$i/}
+    done
+    echo "$from"
+}
+
+line_break() {
     echo "-----------------------------------------------------------"
 }
 
@@ -21,7 +31,7 @@ triggeredBranch=$(git symbolic-ref --short HEAD 2> /dev/null) ||
 triggeredSha1=$(git rev-parse --verify HEAD)
 
 
-signalHandler(){
+signalHandler() {
     echo
     line_break
     echo "Stoping..."
@@ -34,7 +44,7 @@ signalHandler(){
 
 doCommit=$(git config octopus.commit)
 splitByChunk=false
-while getopts "nhvcs:" opt; do
+while getopts "nhvcs:e:" opt; do
   case "$opt" in
     h)
       usage
@@ -54,6 +64,9 @@ while getopts "nhvcs:" opt; do
       splitByChunk=true
       chunkSize=$OPTARG
       ;;
+    e)
+      exclude+=" $OPTARG"
+      ;;
     \?)
       exit 1
       ;;
@@ -69,10 +82,14 @@ shift $(expr $OPTIND - 1)
 
 #Retrive patterns written in the conf
 patterns=$(git config --get-all octopus.pattern)
+excludePatterns=$(git config --get-all octopus.excludePattern)
 
 #Overriding the conf with the patterns given as parameters
 if [[ -n "$@" ]] ; then
     patterns=$@
+fi
+if [[ -n "$exclude" ]]; then
+    excludePatterns=${exclude:1}
 fi
 
 #Exit code 0 if nothing to merge
@@ -81,6 +98,14 @@ if [[ -z "$patterns" ]] ; then
 fi
 
 branches=$(git ls-remote . $patterns | cut -d $'\t' -f 2)
+#Get nothing if excludePatterns is empty
+[[ -n "$excludePatterns" ]] && excludedBranches=$(git ls-remote . $excludePatterns | cut -d $'\t' -f 2)
+branches=$(removeAllFrom "$branches" "$excludedBranches")
+
+[[ -z "$excludedBranches" ]] || echo "Excluding branches :"
+for branch in $excludedBranches ; do
+    echo $'\t'$branch
+done
 
 if [ -z "$branches" ]; then
   echo "No branch matching $patterns were found"

--- a/src/git-octopus
+++ b/src/git-octopus
@@ -121,7 +121,7 @@ do
     sha1sChunk=" ${sha1s[@]:$i:$chunkSize}"
 
     alreadyUpToDate=true
-    for sha1 in "${sha1sChunk[@]}"
+    for sha1 in ${sha1sChunk[@]}
     do
       git merge-base --is-ancestor $sha1 HEAD || alreadyUpToDate=false
     done

--- a/test/exclude_pattern_config_test/Dockerfile
+++ b/test/exclude_pattern_config_test/Dockerfile
@@ -1,0 +1,6 @@
+FROM lesfurets/octopus-tests:simple_merge_latest
+ADD test.sh /home/
+ADD bin /usr/local/bin
+RUN chmod +x /home/test.sh
+WORKDIR /home/octopus-tests/
+CMD /home/test.sh

--- a/test/exclude_pattern_config_test/test.sh
+++ b/test/exclude_pattern_config_test/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#FIXME
+git status &> /dev/null
+
+git checkout features/feat1
+git config octopus.pattern features/*
+git config --add octopus.pattern master
+
+git config octopus.excludePattern "features/feat3"
+
+git octopus
+merged=`git branch --merged`
+if [[ $merged != *feat1* ]] ; then
+	exit 1
+fi
+if [[ $merged != *feat2* ]] ; then
+	exit 1
+fi
+if [[ $merged == *feat3* ]] ; then
+	exit 1
+fi
+if [[ $merged != *master* ]] ; then
+	exit 1
+fi


### PR DESCRIPTION
Implementation of the part 1 of exclude pattern option mentioned in #14. 

The option can be given in command line via,
`git octopus -e features/feat1 -e octopus-* -s 4`
or defined in git config 
`git config octopus.excludePattern features/feat1`
`git config --add octopus.excludePattern octopus-*`

The command line option overrides the git config.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lesfurets/git-octopus/19)

<!-- Reviewable:end -->
