### PR TITLE
Fix package names

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"strconv"
 	"strings"
-	"lesfurets/git-octopus/git"
+	"github.com/lesfurets/git-octopus/git"
 )
 
 type OctopusConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -3,9 +3,9 @@ package config
 import (
 	"errors"
 	"flag"
+	"github.com/lesfurets/git-octopus/git"
 	"strconv"
 	"strings"
-	"github.com/lesfurets/git-octopus/git"
 )
 
 type OctopusConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,8 +3,8 @@ package config
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"lesfurets/git-octopus/git"
-	"lesfurets/git-octopus/test"
+	"github.com/lesfurets/git-octopus/git"
+	"github.com/lesfurets/git-octopus/test"
 )
 
 func createTestRepo() *git.Repository {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,10 +1,10 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
-	"testing"
 	"github.com/lesfurets/git-octopus/git"
 	"github.com/lesfurets/git-octopus/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func createTestRepo() *git.Repository {

--- a/functionnal_tests/basics_test.go
+++ b/functionnal_tests/basics_test.go
@@ -2,14 +2,14 @@ package functionnal_tests
 
 import (
 	"testing"
-	"lesfurets/git-octopus/run"
+	"github.com/lesfurets/git-octopus/run"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"io/ioutil"
 	"strings"
-	"lesfurets/git-octopus/git"
-	"lesfurets/git-octopus/test"
+	"github.com/lesfurets/git-octopus/git"
+	"github.com/lesfurets/git-octopus/test"
 )
 
 func TestVersion(t *testing.T) {

--- a/functionnal_tests/basics_test.go
+++ b/functionnal_tests/basics_test.go
@@ -1,15 +1,15 @@
 package functionnal_tests
 
 import (
-	"testing"
+	"github.com/lesfurets/git-octopus/git"
 	"github.com/lesfurets/git-octopus/run"
+	"github.com/lesfurets/git-octopus/test"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"os"
 	"path/filepath"
-	"io/ioutil"
 	"strings"
-	"github.com/lesfurets/git-octopus/git"
-	"github.com/lesfurets/git-octopus/test"
+	"testing"
 )
 
 func TestVersion(t *testing.T) {

--- a/functionnal_tests/edge_cases_test.go
+++ b/functionnal_tests/edge_cases_test.go
@@ -1,10 +1,10 @@
 package functionnal_tests
 
 import (
-	"testing"
 	"github.com/lesfurets/git-octopus/run"
-	"github.com/stretchr/testify/assert"
 	"github.com/lesfurets/git-octopus/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestOctopusCommitConfigError(t *testing.T) {
@@ -76,7 +76,7 @@ func TestUncleanStateFail(t *testing.T) {
 
 	err := run.Run(context, "*")
 
-	if (assert.NotNil(t, err)) {
+	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "The repository has to be clean.")
 	}
 }

--- a/functionnal_tests/edge_cases_test.go
+++ b/functionnal_tests/edge_cases_test.go
@@ -2,9 +2,9 @@ package functionnal_tests
 
 import (
 	"testing"
-	"lesfurets/git-octopus/run"
+	"github.com/lesfurets/git-octopus/run"
 	"github.com/stretchr/testify/assert"
-	"lesfurets/git-octopus/test"
+	"github.com/lesfurets/git-octopus/test"
 )
 
 func TestOctopusCommitConfigError(t *testing.T) {

--- a/functionnal_tests/no_commit_test.go
+++ b/functionnal_tests/no_commit_test.go
@@ -2,8 +2,8 @@ package functionnal_tests
 
 import (
 	"testing"
-	"lesfurets/git-octopus/run"
-	"lesfurets/git-octopus/test"
+	"github.com/lesfurets/git-octopus/run"
+	"github.com/lesfurets/git-octopus/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/functionnal_tests/no_commit_test.go
+++ b/functionnal_tests/no_commit_test.go
@@ -1,10 +1,10 @@
 package functionnal_tests
 
 import (
-	"testing"
 	"github.com/lesfurets/git-octopus/run"
 	"github.com/lesfurets/git-octopus/test"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestFastForward(t *testing.T) {

--- a/git-octopus.go
+++ b/git-octopus.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"lesfurets/git-octopus/git"
-	"lesfurets/git-octopus/run"
+	"github.com/lesfurets/git-octopus/git"
+	"github.com/lesfurets/git-octopus/run"
 	"log"
 	"os"
 )

--- a/run/matcher.go
+++ b/run/matcher.go
@@ -1,6 +1,6 @@
 package run
 
-import "lesfurets/git-octopus/git"
+import "github.com/lesfurets/git-octopus/git"
 
 func resolveBranchList(repo *git.Repository, patterns []string, excludedPatterns []string) map[string]string {
 	lsRemote, _ := repo.Git(append([]string{"ls-remote", "."}, patterns...)...)

--- a/run/matcher_test.go
+++ b/run/matcher_test.go
@@ -3,7 +3,7 @@ package run
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"lesfurets/git-octopus/test"
+	"github.com/lesfurets/git-octopus/test"
 )
 
 func setupRepo() *OctopusContext {

--- a/run/matcher_test.go
+++ b/run/matcher_test.go
@@ -1,9 +1,9 @@
 package run
 
 import (
+	"github.com/lesfurets/git-octopus/test"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"github.com/lesfurets/git-octopus/test"
 )
 
 func setupRepo() *OctopusContext {

--- a/run/run.go
+++ b/run/run.go
@@ -1,13 +1,13 @@
 package run
 
 import (
-	"github.com/lesfurets/git-octopus/git"
-	"log"
+	"bytes"
 	"errors"
 	"github.com/lesfurets/git-octopus/config"
-	"strings"
-	"bytes"
+	"github.com/lesfurets/git-octopus/git"
 	"github.com/lesfurets/git-octopus/test"
+	"log"
+	"strings"
 )
 
 type OctopusContext struct {
@@ -62,7 +62,7 @@ func Run(context *OctopusContext, args ...string) error {
 	// parents always contains HEAD. We need at lease 2 parents to create a merge commit
 	if octopusConfig.DoCommit && parents != nil && len(parents) > 1 {
 		tree, _ := context.Repo.Git("write-tree")
-		args := []string {"commit-tree"}
+		args := []string{"commit-tree"}
 		for _, parent := range parents {
 			args = append(args, "-p", parent)
 		}
@@ -143,7 +143,6 @@ func mergeHeads(context *OctopusContext, remotes map[string]string) ([]string, e
 func octopusCommitMessage(remotes map[string]string) string {
 	return "octopus commit"
 }
-
 
 func CreateTestContext() (*OctopusContext, *bytes.Buffer) {
 	dir := test.CreateTempDir()

--- a/run/run.go
+++ b/run/run.go
@@ -1,13 +1,13 @@
 package run
 
 import (
-	"lesfurets/git-octopus/git"
+	"github.com/lesfurets/git-octopus/git"
 	"log"
 	"errors"
-	"lesfurets/git-octopus/config"
+	"github.com/lesfurets/git-octopus/config"
 	"strings"
 	"bytes"
-	"lesfurets/git-octopus/test"
+	"github.com/lesfurets/git-octopus/test"
 )
 
 type OctopusContext struct {

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -1,8 +1,8 @@
 package test
 
 import (
-	"io/ioutil"
 	"github.com/lesfurets/git-octopus/git"
+	"io/ioutil"
 	"os"
 )
 

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"io/ioutil"
-	"lesfurets/git-octopus/git"
+	"github.com/lesfurets/git-octopus/git"
 	"os"
 )
 


### PR DESCRIPTION
J'avais des erreurs lors du `go install` de ce type :

```
git-octopus.go:4:2: cannot find package "lesfurets/git-octopus/git" in
any of:
	/usr/local/Cellar/go/1.7.3/libexec/src/lesfurets/git-octopus/git
(from $GOROOT)
	/Users/hvi/go/src/lesfurets/git-octopus/git (from $GOPATH)
```

J'imagine que ça se fix aussi avec un hack de gopath mais je pense que la bonne pratique est de donner le nom complet dans l'import sans toucher au gopath, sinon on ne peut plus `go get` tranquillement le projet git-octopus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lesfurets/git-octopus/28)
<!-- Reviewable:end -->
